### PR TITLE
Fix navigation toggle for small displays.

### DIFF
--- a/site/_includes/themes/apache-clean/_navigation.html
+++ b/site/_includes/themes/apache-clean/_navigation.html
@@ -19,7 +19,7 @@
       <!-- Brand and toggle get grouped for better mobile display -->
 
       <div class="navbar-header page-scroll">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
           <span class="sr-only">Toggle navigation</span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -57,6 +57,3 @@
     <!-- /.container -->
   </nav>
 </div>
-
-
-


### PR DESCRIPTION
The navigation toggle is not working on mobile resolutions. You will only see the 'hamburger' menu, but clicking doesn't have any effect.  By setting the data-target to an id or in this case the element with a certain CSS class this is fixed. 
