### PR TITLE
[BAHIR-90] Add "Download" to home page navigation bar

### DIFF
--- a/site/_includes/themes/apache-clean/_navigation.html
+++ b/site/_includes/themes/apache-clean/_navigation.html
@@ -40,7 +40,6 @@
         <ul class="nav navbar-nav">
           {% for entry in site.data.navigation.topnav %}
           {% comment %}<!-- exclude Download from navbar on the Home page -->{% endcomment %}
-          {% if page.title != "Home" or entry.title != "Download" %}
           <li id="{{ entry.title | slugify }}">
             {% if entry.subcategories %}
             <a href="#" data-toggle="dropdown" class="dropdown-toggle">{{ entry.title }}<b class="caret"></b></a>
@@ -59,7 +58,6 @@
             <a href="{{ entry.url }}" target="{{ target }}">{{ entry.title }}</a>
             {% endif %}
           </li>
-          {% endif %}
           {% endfor %}
         </ul>
       </nav><!--/.navbar-collapse -->

--- a/site/downloads/flink.md
+++ b/site/downloads/flink.md
@@ -25,7 +25,7 @@ limitations under the License.
 
 {% include JB/setup %}
 
-# {{ site.data.project.name }} Extensions for Apache Flink Downloads
+# Download {{ site.data.project.name }} Extensions for Apache Flink
 
 Please find below the latest releases of {{ site.data.project.name }} for Apache Flink Extensions. Note that the binary artifacts for each platform are also published independently through Maven and each [extension documentation page](/docs/flink/overview) describes how to add these artifacts to your application.
 

--- a/site/downloads/spark.md
+++ b/site/downloads/spark.md
@@ -25,11 +25,11 @@ limitations under the License.
 
 {% include JB/setup %}
 
-# {{ site.data.project.name }} Extensions for Apache Spark Downloads
+# Download {{ site.data.project.name }} Extensions for Apache Spark
 
 Please find below the latest releases of {{ site.data.project.name }} for Apache Spark Extensions. Note that the binary artifacts for each platform are also published independently through Maven and each [extension documentation page](/docs/spark/overview) describes how to add these artifacts to your application.
 
-## Bahir Extensions for Apache Spark {{site.data.project.spark_latest_release}} Release
+## Bahir Extensions for Apache Spark Latest Release
 
 {% if site.data.project.spark_latest_release %}
 

--- a/site/index.md
+++ b/site/index.md
@@ -30,8 +30,14 @@ limitations under the License.
 
 Currently, {{ site.data.project.short_name }} provides extensions for [Apache Spark](http://spark.apache.org){:target="_blank"} and [Apache Flink](http://flink.apache.org){:target="_blank"}.
 
-
 ## Apache Spark extensions
+
+{% if site.data.project.spark_latest_release %}
+The latest release for Bahir Spark extensions is {{ site.data.project.spark_latest_release }}, currently providing:
+{% else %}
+Currently, there isn't a release available for Bahir Spark Extensions yet.
+The following extensions are under development and will be supported in the upcoming release:
+{% endif %}
 
  - Spark Structured Streaming data source for MQTT
  - Spark DStream connector for Akka
@@ -41,6 +47,13 @@ Currently, {{ site.data.project.short_name }} provides extensions for [Apache Sp
 
 
 ## Apache Flink extensions
+
+{% if site.data.project.flink_latest_release %}
+The latest release for Bahir Flink extensions is {{ site.data.project.flink_latest_release }}, currently providing:
+{% else %}
+Currently, there isn't a release available for Bahir Flink Extensions yet.
+The following extensions are under development and will be supported in the upcoming release:
+{% endif %}
 
  - Flink streaming connector for ActiveMQ
  - Flink streaming connector for Flume


### PR DESCRIPTION
This PR is a follow up for the suggestions in the JIRA regarding updates to the website.

This also adds information to the home page why there currently isn't a download button for Apache Flink extensions yet.