### PR TITLE
Fixed typos in Apache CouchDB

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -33,10 +33,10 @@ Currently, {{ site.data.project.short_name }} provides extensions for [Apache Sp
 
 ## Apache Spark extensions
 
- - Spark data source for Apache CounchDB/Cloudant ![](assets/themes/apache-clean/img/new-black.png){:height="36px" width="36px"}
+ - Spark data source for Apache CouchDB/Cloudant ![](assets/themes/apache-clean/img/new-black.png){:height="36px" width="36px"}
  - Spark Structured Streaming data source for Akka ![](assets/themes/apache-clean/img/new-black.png){:height="36px" width="36px"}
  - Spark Structured Streaming data source for MQTT
- - Spark DStream connector for Apache CounchDB/Cloudant ![](assets/themes/apache-clean/img/new-black.png){:height="36px" width="36px"}
+ - Spark DStream connector for Apache CouchDB/Cloudant ![](assets/themes/apache-clean/img/new-black.png){:height="36px" width="36px"}
  - Spark DStream connector for Akka
  - Spark DStream connector for Google Cloud Pub/Sub ![](assets/themes/apache-clean/img/new-black.png){:height="36px" width="36px"}
  - Spark DStream connector for MQTT


### PR DESCRIPTION
Apache CouchDB is incorrectly referred to as `CounchDB` twice on the website.
This PR corrects those typos.