### PR TITLE
Fix link to Redis documentation

### DIFF
--- a/site/docs/flink/1.0/flink-streaming-redis.md
+++ b/site/docs/flink/1.0/flink-streaming-redis.md
@@ -155,7 +155,7 @@ This section gives a description of all the available data types and what Redis 
             </td>
         </tr>
         <tr>
-            <td>SET</td><td><a href="http://redis.io/commands/rpush">SADD</a></td>
+            <td>SET</td><td><a href="http://redis.io/commands/sadd">SADD</a></td>
         </tr>
         <tr>
             <td>PUBSUB</td><td><a href="http://redis.io/commands/publish">PUBLISH</a></td>

--- a/site/docs/flink/current/flink-streaming-redis.md
+++ b/site/docs/flink/current/flink-streaming-redis.md
@@ -155,7 +155,7 @@ This section gives a description of all the available data types and what Redis 
             </td>
         </tr>
         <tr>
-            <td>SET</td><td><a href="http://redis.io/commands/rpush">SADD</a></td>
+            <td>SET</td><td><a href="http://redis.io/commands/sadd">SADD</a></td>
         </tr>
         <tr>
             <td>PUBSUB</td><td><a href="http://redis.io/commands/publish">PUBLISH</a></td>


### PR DESCRIPTION
Currently the text says `SADD` while the link points to `rpush`.